### PR TITLE
Require Composer v1

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -142,8 +142,8 @@ ynh_store_file_checksum --file="$final_path/config/db.inc.php"
 (
 	cd "$final_path"
 	export COMPOSER_HOME=$final_path
-	curl -sS https://getcomposer.org/installer | php -- --install-dir="$final_path" \
-		&& php"${phpversion}" composer.phar install --no-interaction --quiet
+	curl -sS https://getcomposer.org/installer | php -- --version="1.10.16" --install-dir="$final_path" \
+		&& php"${phpversion}" composer.phar install --no-interaction
 )
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -148,7 +148,7 @@ chown -R $app $final_path/src/Movim/Bootstrap.php
 
 (
 	cd "$final_path"
-	curl -sS https://getcomposer.org/installer | php -- --install-dir="$final_path" \
+	curl -sS https://getcomposer.org/installer | php -- --version="1.10.16" --install-dir="$final_path" \
 		&& php composer.phar config --global discard-changes true --quiet \
 		&& php composer.phar install --no-interaction --quiet
 )


### PR DESCRIPTION
## Problem
- Closes #14 
- wikimedia/composer-merge-plugin is currently not compatible with Composer v2

## Solution
- Download Composer v1 instead of default v2

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Package_check results
---

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/movim_ynh%20PR15%20(tituspijean)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/movim_ynh%20PR15%20(tituspijean)/)  
