### PR TITLE
Fix linter warning

### DIFF
--- a/check_process
+++ b/check_process
@@ -26,16 +26,7 @@
 		port_already_use=1
 		change_url=0
 ;;; Levels
-	Level 1=auto
-	Level 2=auto
-	Level 3=auto
-	Level 4=auto
 	Level 5=auto
-	Level 6=auto
-	Level 7=auto
-	Level 8=0
-	Level 9=0
-	Level 10=0
 ;;; Options
 Email=
 Notification=none

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Web-based cross-platform XMPP client",
         "fr": "Client XMPP multiplateforme basé sur le Web"
     },
-    "version": "0.18~ynh2",
+    "version": "0.18~ynh3",
     "url": "https://movim.eu",
     "license": "AGPL-3.0-or-later",
     "maintainer": {

--- a/scripts/install
+++ b/scripts/install
@@ -120,7 +120,7 @@ ynh_script_progression --message="Configuring PHP-FPM..." --weight=1
 # Create a dedicated PHP-FPM config
 ynh_replace_string --match_string="__TIMEZONE__" --replace_string="$timezone" --target_file=../conf/php-fpm.conf
 
-ynh_add_fpm_config --phpversion=$YNH_PHP_VERSION --package="$extra_php_dependencies"
+ynh_add_fpm_config --package="$extra_php_dependencies"
 phpversion=$(ynh_app_setting_get --app="$app" --key=phpversion)
 
 #=================================================

--- a/scripts/remove
+++ b/scripts/remove
@@ -25,6 +25,17 @@ db_user=$db_name
 #=================================================
 # STANDARD REMOVE
 #=================================================
+# REMOVE SERVICE INTEGRATION IN YUNOHOST
+#=================================================
+
+# Remove the service from the list of services known by YunoHost (added from `yunohost service add`)
+if ynh_exec_warn_less yunohost service status $app >/dev/null
+then
+	ynh_script_progression --message="Removing $app service integration..." --weight=1
+	yunohost service remove $app
+fi
+
+#=================================================
 # STOP AND REMOVE SERVICE
 #=================================================
 ynh_script_progression --message="Stopping and removing the systemd service" --weight=1

--- a/scripts/restore
+++ b/scripts/restore
@@ -113,7 +113,7 @@ systemctl enable $app.service
 # INTEGRATE SERVICE IN YUNOHOST
 #=================================================
 
-yunohost service add $app --description "Responsive web-based XMPP client" --log "/var/log/$app/$app.log"
+yunohost service add $app --description "Responsive web-based XMPP client" --log="/var/log/$app/$app.log"
 
 #=================================================
 # START SYSTEMD SERVICE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -132,7 +132,7 @@ ynh_script_progression --message="Upgrading PHP-FPM configuration..." --weight=1
 # Create a dedicated PHP-FPM config
 ynh_replace_string --match_string="__TIMEZONE__" --replace_string="$timezone" --target_file=../conf/php-fpm.conf
 
-ynh_add_fpm_config --phpversion=$YNH_PHP_VERSION --package="$extra_php_dependencies"
+ynh_add_fpm_config --package="$extra_php_dependencies"
 phpversion=$(ynh_app_setting_get --app="$app" --key=phpversion)
 
 #=================================================
@@ -141,6 +141,13 @@ phpversion=$(ynh_app_setting_get --app="$app" --key=phpversion)
 
 chown -R $app:www-data $final_path
 chown -R $app $final_path/src/Movim/Bootstrap.php
+
+#=================================================
+# INTEGRATE SERVICE IN YUNOHOST
+#=================================================
+ynh_script_progression --message="Integrating service in YunoHost..." --weight=1
+
+yunohost service add $app --description "Responsive web-based XMPP client" --log="/var/log/$app/$app.log"
 
 #=================================================
 # Install PHP dependencies using composer


### PR DESCRIPTION
c.f. : 

```
 ! Found some inconsistencies in the 'yunohost service add' commands between install, upgrade and restore:
   install : 
      yunohost service add $app --description Responsive web-based XMPP client --log=/var/log/$app/$app.log
   upgrade : 
      yunohost service add $app --description Responsive web-based XMPP client --log=/var/log/$app/$app.log
   restore : 
      yunohost service add $app --description Responsive web-based XMPP client --log /var/log/$app/$app.log 
```